### PR TITLE
Using new data classification model

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging/tests/Common/Microsoft.Extensions.Logging.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.Logging/tests/Common/Microsoft.Extensions.Logging.Tests.csproj
@@ -3,21 +3,16 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent);$(NetFrameworkMinimum)</TargetFrameworks>
     <EnableDefaultItems>true</EnableDefaultItems>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\DI.Common\Common\src\TestSink.cs"
-             Link="tests\DI.Common\Common\src\TestSink.cs" />
-    <Compile Include="..\DI.Common\Common\src\WriteContext.cs"
-             Link="tests\DI.Common\Common\src\WriteContext.cs" />
-    <Compile Include="..\DI.Common\Common\src\BeginScopeContext.cs"
-             Link="tests\DI.Common\Common\src\BeginScopeContext.cs" />
-    <Compile Include="..\DI.Common\Common\src\ITestSink.cs"
-             Link="tests\DI.Common\Common\src\ITestSink.cs" />
-    <Compile Include="..\DI.Common\Common\src\TestLogger.cs"
-             Link="tests\DI.Common\Common\src\TestLogger.cs" />
-    <Compile Include="..\DI.Common\Common\src\TestLoggerFactory.cs"
-             Link="tests\DI.Common\Common\src\TestLoggerFactory.cs" />
+    <Compile Include="..\DI.Common\Common\src\TestSink.cs" Link="tests\DI.Common\Common\src\TestSink.cs" />
+    <Compile Include="..\DI.Common\Common\src\WriteContext.cs" Link="tests\DI.Common\Common\src\WriteContext.cs" />
+    <Compile Include="..\DI.Common\Common\src\BeginScopeContext.cs" Link="tests\DI.Common\Common\src\BeginScopeContext.cs" />
+    <Compile Include="..\DI.Common\Common\src\ITestSink.cs" Link="tests\DI.Common\Common\src\ITestSink.cs" />
+    <Compile Include="..\DI.Common\Common\src\TestLogger.cs" Link="tests\DI.Common\Common\src\TestLogger.cs" />
+    <Compile Include="..\DI.Common\Common\src\TestLoggerFactory.cs" Link="tests\DI.Common\Common\src\TestLoggerFactory.cs" />
 
     <TrimmerRootDescriptor Include="$(ILLinkDescriptorsPath)ILLink.Descriptors.Castle.xml" />
     <TrimmerRootDescriptor Include="$(MSBuildThisFileDirectory)..\ILLink.Descriptors.xml" />

--- a/src/libraries/Microsoft.Extensions.Logging/tests/Common/Redaction/Compliance/DataClassification.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/tests/Common/Redaction/Compliance/DataClassification.cs
@@ -1,0 +1,155 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.Extensions.Compliance.Classification;
+
+/// <summary>
+/// Represents a set of data classes as a part of a data taxonomy.
+/// </summary>
+public readonly struct DataClassification : IEquatable<DataClassification>
+{
+    /// <summary>
+    /// Represents unclassified data.
+    /// </summary>
+    public const ulong NoneTaxonomyValue = 0UL;
+
+    /// <summary>
+    /// Represents the unknown classification.
+    /// </summary>
+    public const ulong UnknownTaxonomyValue = 1UL << 63;
+
+    /// <summary>
+    /// Gets the value to represent data with no defined classification.
+    /// </summary>
+    public static DataClassification None => new(NoneTaxonomyValue);
+
+    /// <summary>
+    /// Gets the value to represent data with an unknown classification.
+    /// </summary>
+    public static DataClassification Unknown => new(UnknownTaxonomyValue);
+
+    /// <summary>
+    /// Gets the name of the taxonomy that recognizes this classification.
+    /// </summary>
+    public string TaxonomyName { get; }
+
+    /// <summary>
+    /// Gets the bit mask representing the data classes.
+    /// </summary>
+    public ulong Value { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DataClassification"/> struct.
+    /// </summary>
+    /// <param name="taxonomyName">The name of the taxonomy this classification belongs to.</param>
+    /// <param name="value">The taxonomy-specific bit vector representing the data classes.</param>
+    /// <exception cref="ArgumentException">Bit 63, which corresponds to <see cref="UnknownTaxonomyValue"/>, is set in the <paramref name="value"/> value.</exception>
+    public DataClassification(string taxonomyName, ulong value)
+    {
+        if (string.IsNullOrEmpty(taxonomyName))
+        {
+            throw new ArgumentNullException(nameof(taxonomyName));
+        }
+
+        TaxonomyName = taxonomyName;
+        Value = value;
+
+        if (((value & UnknownTaxonomyValue) != 0) || (value == NoneTaxonomyValue))
+        {
+            throw new ArgumentException($"Cannot create a classification with a value of 0x{value:x}.", nameof(value));
+        }
+    }
+
+    private DataClassification(ulong taxonomyValue)
+    {
+        TaxonomyName = string.Empty;
+        Value = taxonomyValue;
+    }
+
+    /// <summary>
+    /// Checks if object is equal to this instance of <see cref="DataClassification"/>.
+    /// </summary>
+    /// <param name="obj">Object to check for equality.</param>
+    /// <returns><see langword="true" /> if object instances are equal <see langword="false" /> otherwise.</returns>
+    public override bool Equals(object? obj) => (obj is DataClassification dc) && Equals(dc);
+
+    /// <summary>
+    /// Checks if object is equal to this instance of <see cref="DataClassification"/>.
+    /// </summary>
+    /// <param name="other">Instance of <see cref="DataClassification"/> to check for equality.</param>
+    /// <returns><see langword="true" /> if object instances are equal <see langword="false" /> otherwise.</returns>
+    public bool Equals(DataClassification other) => other.TaxonomyName == TaxonomyName && other.Value == Value;
+
+    /// <summary>
+    /// Get the hash code the current instance.
+    /// </summary>
+    /// <returns>Hash code.</returns>
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(TaxonomyName, Value);
+    }
+
+    /// <summary>
+    /// Check if two instances are equal.
+    /// </summary>
+    /// <param name="left">Left argument of the comparison.</param>
+    /// <param name="right">Right argument of the comparison.</param>
+    /// <returns><see langword="true" /> if object instances are equal, or <see langword="false" /> otherwise.</returns>
+    public static bool operator ==(DataClassification left, DataClassification right)
+    {
+        return left.Equals(right);
+    }
+
+    /// <summary>
+    /// Check if two instances are not equal.
+    /// </summary>
+    /// <param name="left">Left argument of the comparison.</param>
+    /// <param name="right">Right argument of the comparison.</param>
+    /// <returns><see langword="false" /> if object instances are equal, or <see langword="true" /> otherwise.</returns>
+    public static bool operator !=(DataClassification left, DataClassification right)
+    {
+        return !left.Equals(right);
+    }
+
+    /// <summary>
+    /// Combines together two data classifications.
+    /// </summary>
+    /// <param name="left">The first classification to combine.</param>
+    /// <param name="right">The second classification to combine.</param>
+    /// <returns>A new classification object representing the combination of the two input classifications.</returns>
+    /// <exception cref="ArgumentException">The two classifications aren't part of the same taxonomy.</exception>
+    public static DataClassification Combine(DataClassification left, DataClassification right)
+    {
+        if (string.IsNullOrEmpty(left.TaxonomyName))
+        {
+            return (left.Value == NoneTaxonomyValue) ? right : Unknown;
+        }
+        else if (string.IsNullOrEmpty(right.TaxonomyName))
+        {
+            return (right.Value == NoneTaxonomyValue) ? left : Unknown;
+        }
+
+        if (left.TaxonomyName != right.TaxonomyName)
+        {
+            throw new ArgumentException($"Mismatched data taxonomies: {left.TaxonomyName} and {right.TaxonomyName} cannot be combined", nameof(right));
+        }
+
+        return new(left.TaxonomyName, left.Value | right.Value);
+    }
+
+    /// <summary>
+    /// Combines together two data classifications.
+    /// </summary>
+    /// <param name="left">The first classification to combine.</param>
+    /// <param name="right">The second classification to combine.</param>
+    /// <returns>A new classification object representing the combination of the two input classifications.</returns>
+    /// <exception cref="ArgumentException">The two classifications aren't part of the same taxonomy.</exception>
+    [SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "It's called Combine")]
+    public static DataClassification operator |(DataClassification left, DataClassification right)
+    {
+        return Combine(left, right);
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Logging/tests/Common/Redaction/Compliance/DataClassificationAttribute.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/tests/Common/Redaction/Compliance/DataClassificationAttribute.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.Extensions.Compliance.Classification;
+
+/// <summary>
+/// Base attribute for data classification.
+/// </summary>
+[AttributeUsage(
+    AttributeTargets.Field
+    | AttributeTargets.Property
+    | AttributeTargets.Parameter
+    | AttributeTargets.Class
+    | AttributeTargets.Struct
+    | AttributeTargets.Interface
+    | AttributeTargets.ReturnValue
+    | AttributeTargets.GenericParameter,
+    AllowMultiple = true)]
+#pragma warning disable CA1813 // Avoid unsealed attributes
+public class DataClassificationAttribute : Attribute
+#pragma warning restore CA1813 // Avoid unsealed attributes
+{
+    /// <summary>
+    /// Gets or sets the notes.
+    /// </summary>
+    /// <remarks>Optional free-form text to provide context during a privacy audit.</remarks>
+    public string Notes { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets the data class represented by this attribute.
+    /// </summary>
+    public DataClassification Classification { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DataClassificationAttribute"/> class.
+    /// </summary>
+    /// <param name="classification">The data classification to apply.</param>
+    protected DataClassificationAttribute(DataClassification classification)
+    {
+        Classification = classification;
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Logging/tests/Common/Redaction/Compliance/IRedactorBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/tests/Common/Redaction/Compliance/IRedactorBuilder.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.Extensions.Compliance.Classification;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.Extensions.Compliance.Redaction;
+
+/// <summary>
+/// Adds redactors to the application.
+/// </summary>
+public interface IRedactionBuilder
+{
+    /// <summary>
+    /// Gets the service collection into which the redactor instances are registered.
+    /// </summary>
+    IServiceCollection Services { get; }
+
+    /// <summary>
+    /// Sets the redactor to use for a set of data classes.
+    /// </summary>
+    /// <typeparam name="T">Redactor type.</typeparam>
+    /// <param name="classifications">The data classes for which the redactor type should be used.</param>
+    /// <returns>The value of this instance.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="classifications" /> is <see langword="null" />.</exception>
+    IRedactionBuilder SetRedactor<T>(params DataClassification[] classifications)
+        where T : Redactor;
+
+    /// <summary>
+    /// Sets the redactor to use when processing classified data for which no specific redactor has been registered.
+    /// </summary>
+    /// <typeparam name="T">Redactor type.</typeparam>
+    /// <returns>The value of this instance.</returns>
+    IRedactionBuilder SetFallbackRedactor<T>()
+        where T : Redactor;
+}

--- a/src/libraries/Microsoft.Extensions.Logging/tests/Common/Redaction/Compliance/IRedactorProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/tests/Common/Redaction/Compliance/IRedactorProvider.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Compliance.Classification;
+
+namespace Microsoft.Extensions.Compliance.Redaction;
+
+/// <summary>
+/// Provides redactors for different data classes.
+/// </summary>
+public interface IRedactorProvider
+{
+    /// <summary>
+    /// Gets the redactor configured to handle the specified data class.
+    /// </summary>
+    /// <param name="classification">Data classification of the data to redact.</param>
+    /// <returns>A redactor suitable to redact data of the given class.</returns>
+    Redactor GetRedactor(DataClassification classification);
+}

--- a/src/libraries/Microsoft.Extensions.Logging/tests/Common/Redaction/Compliance/PrivateDataAttributes.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/tests/Common/Redaction/Compliance/PrivateDataAttributes.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Compliance.Classification;
+
+namespace Microsoft.Extensions.Compliance.Testing;
+
+/// <summary>
+/// Private data.
+/// </summary>
+public sealed class PrivateDataAttribute : DataClassificationAttribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PrivateDataAttribute"/> class.
+    /// </summary>
+    public PrivateDataAttribute()
+        : base(SimpleClassifications.PrivateData)
+    {
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Logging/tests/Common/Redaction/Compliance/PublicDataAttribute.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/tests/Common/Redaction/Compliance/PublicDataAttribute.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Compliance.Classification;
+
+namespace Microsoft.Extensions.Compliance.Testing;
+
+/// <summary>
+/// Public data.
+/// </summary>
+public sealed class PublicDataAttribute : DataClassificationAttribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PublicDataAttribute"/> class.
+    /// </summary>
+    public PublicDataAttribute()
+        : base(SimpleClassifications.PublicData)
+    {
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Logging/tests/Common/Redaction/Compliance/Redactor.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/tests/Common/Redaction/Compliance/Redactor.cs
@@ -1,0 +1,199 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+#if !NETCOREAPP3_1_OR_GREATER
+using System.Buffers;
+#endif
+
+namespace Microsoft.Extensions.Compliance.Redaction;
+
+/// <summary>
+/// Enables the redaction of potentially sensitive data.
+/// </summary>
+public abstract class Redactor
+{
+#if NET6_0_OR_GREATER
+    private const int MaximumStackAllocation = 256;
+#endif
+
+    /// <summary>
+    /// Redacts potentially sensitive data.
+    /// </summary>
+    /// <param name="source">Value to redact.</param>
+    /// <returns>Redacted value.</returns>
+    public string Redact(ReadOnlySpan<char> source)
+    {
+        if (source.IsEmpty)
+        {
+            return string.Empty;
+        }
+
+        var length = GetRedactedLength(source);
+
+#if NETCOREAPP3_1_OR_GREATER
+        unsafe
+        {
+#pragma warning disable 8500
+            return string.Create(
+                length,
+                (this, (IntPtr)(&source)),
+                (destination, state) => state.Item1.Redact(*(ReadOnlySpan<char>*)state.Item2, destination));
+#pragma warning restore 8500
+        }
+#else
+        var buffer = ArrayPool<char>.Shared.Rent(length);
+
+        try
+        {
+            var charsWritten = Redact(source, buffer);
+            var redactedString = new string(buffer, 0, charsWritten);
+
+            return redactedString;
+        }
+        finally
+        {
+            ArrayPool<char>.Shared.Return(buffer);
+        }
+#endif
+    }
+
+    /// <summary>
+    /// Redacts potentially sensitive data.
+    /// </summary>
+    /// <param name="source">Value to redact.</param>
+    /// <param name="destination">Buffer to store redacted value.</param>
+    /// <returns>Number of characters produced when redacting the given source input.</returns>
+    /// <exception cref="ArgumentException"><paramref name="destination"/> is too small.</exception>
+    public abstract int Redact(ReadOnlySpan<char> source, Span<char> destination);
+
+    /// <summary>
+    /// Redacts potentially sensitive data.
+    /// </summary>
+    /// <param name="source">Value to redact.</param>
+    /// <param name="destination">Buffer to redact into.</param>
+    /// <remarks>
+    /// Returns 0 when <paramref name="source"/> is <see langword="null"/>.
+    /// </remarks>
+    /// <returns>Number of characters written to the buffer.</returns>
+    /// <exception cref="ArgumentException"><paramref name="destination"/> is too small.</exception>
+    public int Redact(string? source, Span<char> destination) => Redact(source.AsSpan(), destination);
+
+    /// <summary>
+    /// Redacts potentially sensitive data.
+    /// </summary>
+    /// <param name="source">Value to redact.</param>
+    /// <returns>Redacted value.</returns>
+    /// <remarks>
+    /// Returns an empty string when <paramref name="source"/> is <see langword="null"/>.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+    public virtual string Redact(string? source) => Redact(source.AsSpan());
+
+    /// <summary>
+    /// Redacts potentially sensitive data.
+    /// </summary>
+    /// <typeparam name="T">Type of value to redact.</typeparam>
+    /// <param name="value">Value to redact.</param>
+    /// <param name="format">
+    /// The optional format that selects the specific formatting operation performed. Refer to the
+    /// documentation of the type being formatted to understand the values you can supply here.
+    /// </param>
+    /// <param name="provider">Format provider to retrieve format for span formattable.</param>
+    /// <returns>Redacted value.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="value"/> is <see langword="null"/>.</exception>
+    [SuppressMessage("Minor Code Smell", "S3247:Duplicate casts should not be made", Justification = "Avoid pattern matching to improve jitted code")]
+    public string Redact<T>(T value, string? format = null, IFormatProvider? provider = null)
+    {
+#if NET6_0_OR_GREATER
+        if (value is ISpanFormattable)
+        {
+            Span<char> buffer = stackalloc char[MaximumStackAllocation];
+
+            // Stryker disable all : Cannot kill the mutant because the only difference is allocating buffer on stack or renting it.
+            // Null forgiving operator: The null case is checked with default equality comparer, but compiler doesn't understand it.
+            if (((ISpanFormattable)value).TryFormat(buffer, out var written, format.AsSpan(), provider))
+            {
+                // Stryker enable all : Cannot kill the mutant because the only difference is allocating buffer on stack or renting it.
+
+                var formatted = buffer.Slice(0, written);
+                var length = GetRedactedLength(formatted);
+
+                unsafe
+                {
+#pragma warning disable 8500
+                    return string.Create(
+                        length,
+                        (this, (IntPtr)(&formatted)),
+                        (destination, state) => state.Item1.Redact(*(ReadOnlySpan<char>*)state.Item2, destination));
+#pragma warning restore 8500
+                }
+            }
+        }
+#endif
+
+        if (value is IFormattable)
+        {
+            return Redact(((IFormattable)value).ToString(format, provider));
+        }
+
+        return Redact(value?.ToString());
+    }
+
+    /// <summary>
+    /// Redacts potentially sensitive data.
+    /// </summary>
+    /// <typeparam name="T">Type of value to redact.</typeparam>
+    /// <param name="value">Value to redact.</param>
+    /// <param name="destination">Buffer to redact into.</param>
+    /// <param name="format">
+    /// The optional format string that selects the specific formatting operation performed. Refer to the
+    /// documentation of the type being formatted to understand the values you can supply here.
+    /// </param>
+    /// <param name="provider">Format provider to retrieve format for span formattable.</param>
+    /// <returns>Number of characters written to the buffer.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="value"/> is <see langword="null"/>.</exception>
+    [SuppressMessage("Minor Code Smell", "S3247:Duplicate casts should not be made", Justification = "Avoid pattern matching to improve jitted code")]
+    public int Redact<T>(T value, Span<char> destination, string? format = null, IFormatProvider? provider = null)
+    {
+#if NET6_0_OR_GREATER
+        if (value is ISpanFormattable)
+        {
+            Span<char> buffer = stackalloc char[MaximumStackAllocation];
+
+            // Stryker disable all : Cannot kill the mutant because the only difference is allocating buffer on stack or renting it.
+            if (((ISpanFormattable)value).TryFormat(buffer, out var written, format.AsSpan(), provider))
+            {
+                // Stryker enable all : Cannot kill the mutant because the only difference is allocating buffer on stack or renting it.
+                var formatted = buffer.Slice(0, written);
+
+                return Redact(formatted, destination);
+            }
+        }
+#endif
+
+        if (value is IFormattable)
+        {
+            return Redact(((IFormattable)value).ToString(format, provider), destination);
+        }
+
+        return Redact(value?.ToString(), destination);
+    }
+
+    /// <summary>
+    /// Gets the number of characters produced by redacting the input.
+    /// </summary>
+    /// <param name="input">Value to be redacted.</param>
+    /// <returns>Minimum buffer size.</returns>
+    public abstract int GetRedactedLength(ReadOnlySpan<char> input);
+
+    /// <summary>
+    /// Gets the number of characters produced by redacting the input.
+    /// </summary>
+    /// <param name="input">Value to be redacted.</param>
+    /// <returns>Minimum buffer size.</returns>
+    public int GetRedactedLength(string? input) => GetRedactedLength(input.AsSpan());
+}

--- a/src/libraries/Microsoft.Extensions.Logging/tests/Common/Redaction/Compliance/SimpleClassifications.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/tests/Common/Redaction/Compliance/SimpleClassifications.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Compliance.Classification;
+
+namespace Microsoft.Extensions.Compliance.Testing;
+
+/// <summary>
+/// Simple data classifications.
+/// </summary>
+public static class SimpleClassifications
+{
+    /// <summary>
+    /// Gets the name of this classification taxonomy.
+    /// </summary>
+    public static string TaxonomyName => typeof(SimpleTaxonomy).FullName!;
+
+    /// <summary>
+    /// Gets the private data classification.
+    /// </summary>
+    public static DataClassification PrivateData => new(TaxonomyName, (ulong)SimpleTaxonomy.PrivateData);
+
+    /// <summary>
+    /// Gets the public data classification.
+    /// </summary>
+    public static DataClassification PublicData => new(TaxonomyName, (ulong)SimpleTaxonomy.PublicData);
+}

--- a/src/libraries/Microsoft.Extensions.Logging/tests/Common/Redaction/Compliance/SimpleTaxonomy.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/tests/Common/Redaction/Compliance/SimpleTaxonomy.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.Extensions.Compliance.Classification;
+
+namespace Microsoft.Extensions.Compliance.Testing;
+
+/// <summary>
+/// Classes of data used for simple scenarios.
+/// </summary>
+[Flags]
+public enum SimpleTaxonomy : ulong
+{
+    /// <summary>
+    /// No data classification.
+    /// </summary>
+    None = DataClassification.NoneTaxonomyValue,
+
+    /// <summary>
+    /// This is public data.
+    /// </summary>
+    PublicData = 1 << 0,
+
+    /// <summary>
+    /// This is private data.
+    /// </summary>
+    PrivateData = 1 << 1,
+
+    /// <summary>
+    /// Unknown data classification, handle with care.
+    /// </summary>
+    Unknown = DataClassification.UnknownTaxonomyValue,
+}

--- a/src/libraries/Microsoft.Extensions.Logging/tests/Common/Redaction/TestRedactor.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/tests/Common/Redaction/TestRedactor.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Globalization;
+using Microsoft.Extensions.Compliance.Classification;
+using Microsoft.Extensions.Compliance.Redaction;
+
+namespace Microsoft.Extensions.Logging.Tests.Redaction
+{
+
+    internal sealed class TestRedactorProvider : IRedactorProvider
+    {
+        public Redactor GetRedactor(DataClassification classification) => new TestRedactor(classification);
+    }
+
+    internal sealed class TestRedactor : Redactor
+    {
+        private readonly string _redactedText;
+
+        public TestRedactor(DataClassification classification)
+        {
+            _redactedText = $"[Redacted - {classification.Value.ToString(CultureInfo.InvariantCulture)}]";
+        }
+
+        override public int GetRedactedLength(ReadOnlySpan<char> source) => _redactedText.Length;
+
+        override public int Redact(ReadOnlySpan<char> source, Span<char> destination)
+        {
+            _redactedText.AsSpan().CopyTo(destination);
+            return _redactedText.Length;
+        }
+    }
+}


### PR DESCRIPTION
Replaces simple test classes by actual ones from extensions, and also uses the new model which doesn't use Enums as classification values (ulong now).