### PR TITLE
Address review feedback: fix GetNumberGenerations for Server GC and D…

### DIFF
--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
@@ -4503,9 +4503,11 @@ public sealed unsafe partial class SOSDacImpl
                 throw new ArgumentException();
 
             IGC gc = _target.Contracts.GC;
-            GCHeapData heapData = gc.GetHeapData();
-            uint totalGenerationCount = (uint)heapData.GenerationTable.Count;
-            *pGenerations = totalGenerationCount;
+            string[] gcIdentifiers = gc.GetGCIdentifiers();
+            GCHeapData heapData = gcIdentifiers.Contains(GCIdentifiers.Server)
+                ? gc.GetHeapData(gc.GetGCHeaps().First())
+                : gc.GetHeapData();
+            *pGenerations = (uint)heapData.GenerationTable.Count;
         }
         catch (System.Exception ex)
         {
@@ -4578,7 +4580,7 @@ public sealed unsafe partial class SOSDacImpl
                 }
                 if (hr == HResults.S_OK && pGenerationData is not null)
                 {
-                    for (int i = 0; i < (int)cGenerations; i++)
+                    for (int i = 0; i < (int)pNeededLocal; i++)
                     {
                         Debug.Assert(pGenDataLocal[i].start_segment == pGenerationData[i].start_segment);
                         Debug.Assert(pGenDataLocal[i].allocation_start == pGenerationData[i].allocation_start);
@@ -4639,7 +4641,7 @@ public sealed unsafe partial class SOSDacImpl
                 }
                 if (hr == HResults.S_OK && pFinalizationFillPointers is not null)
                 {
-                    for (int i = 0; i < (int)cFillPointers; i++)
+                    for (int i = 0; i < (int)pNeededLocal; i++)
                     {
                         Debug.Assert(pFillPointersLocal[i] == pFinalizationFillPointers[i]);
                     }
@@ -4701,7 +4703,7 @@ public sealed unsafe partial class SOSDacImpl
                 }
                 if (hr == HResults.S_OK && pGenerationData is not null)
                 {
-                    for (int i = 0; i < (int)cGenerations; i++)
+                    for (int i = 0; i < (int)pNeededLocal; i++)
                     {
                         Debug.Assert(pGenDataLocal[i].start_segment == pGenerationData[i].start_segment);
                         Debug.Assert(pGenDataLocal[i].allocation_start == pGenerationData[i].allocation_start);
@@ -4762,7 +4764,8 @@ public sealed unsafe partial class SOSDacImpl
                 }
                 if (hr == HResults.S_OK && pFinalizationFillPointers is not null)
                 {
-                    for (int i = 0; i < (int)cFillPointers; i++)
+                    int fillPointersToCompare = (int)Math.Min(cFillPointers, pNeededLocal);
+                    for (int i = 0; i < fillPointersToCompare; i++)
                     {
                         Debug.Assert(pFillPointersLocal[i] == pFinalizationFillPointers[i]);
                     }

--- a/src/native/managed/cdac/tests/MockDescriptors/MockDescriptors.GC.cs
+++ b/src/native/managed/cdac/tests/MockDescriptors/MockDescriptors.GC.cs
@@ -69,6 +69,8 @@ internal static class GCHeapBuilderExtensions
         [
             new(nameof(Data.GCAllocContext.Pointer), DataType.pointer),
             new(nameof(Data.GCAllocContext.Limit), DataType.pointer),
+            new(nameof(Data.GCAllocContext.AllocBytes), DataType.int64),
+            new(nameof(Data.GCAllocContext.AllocBytesLoh), DataType.int64),
         ]
     };
 
@@ -299,6 +301,7 @@ internal static class GCHeapBuilderExtensions
         helpers.Write(maxGenGlobal.Data.AsSpan(0, sizeof(uint)), genCount - 1);
         memBuilder.AddHeapFragment(maxGenGlobal);
 
+        // Handle table globals required by GCFactory
         targetBuilder.AddTypes(types);
         targetBuilder.AddGlobals(
             (nameof(Constants.Globals.TotalGenerationCount), genCount),
@@ -307,6 +310,10 @@ internal static class GCHeapBuilderExtensions
             (nameof(Constants.Globals.CompactReasonsLength), 0UL),
             (nameof(Constants.Globals.ExpandMechanismsLength), 0UL),
             (nameof(Constants.Globals.InterestingMechanismBitsLength), 0UL),
+            (nameof(Constants.Globals.HandlesPerBlock), 32UL),
+            (nameof(Constants.Globals.BlockInvalid), 1UL),
+            (nameof(Constants.Globals.DebugDestroyedHandleValue), 0UL),
+            (nameof(Constants.Globals.HandleMaxInternalTypes), 12UL),
             (nameof(Constants.Globals.GCHeapMarkArray), markArrayGlobal.Address),
             (nameof(Constants.Globals.GCHeapNextSweepObj), nextSweepObjGlobal.Address),
             (nameof(Constants.Globals.GCHeapBackgroundMinSavedAddr), bgMinGlobal.Address),
@@ -390,6 +397,7 @@ internal static class GCHeapBuilderExtensions
         helpers.Write(maxGenGlobal.Data.AsSpan(0, sizeof(uint)), genCount - 1);
         memBuilder.AddHeapFragment(maxGenGlobal);
 
+        // Handle table globals required by GCFactory
         targetBuilder.AddTypes(types);
         targetBuilder.AddGlobals(
             (nameof(Constants.Globals.TotalGenerationCount), genCount),
@@ -398,6 +406,10 @@ internal static class GCHeapBuilderExtensions
             (nameof(Constants.Globals.CompactReasonsLength), 0UL),
             (nameof(Constants.Globals.ExpandMechanismsLength), 0UL),
             (nameof(Constants.Globals.InterestingMechanismBitsLength), 0UL),
+            (nameof(Constants.Globals.HandlesPerBlock), 32UL),
+            (nameof(Constants.Globals.BlockInvalid), 1UL),
+            (nameof(Constants.Globals.DebugDestroyedHandleValue), 0UL),
+            (nameof(Constants.Globals.HandleMaxInternalTypes), 12UL),
             (nameof(Constants.Globals.NumHeaps), numHeapsGlobal.Address),
             (nameof(Constants.Globals.Heaps), heapsGlobal.Address),
             (nameof(Constants.Globals.GCLowestAddress), lowestAddrGlobal.Address),

--- a/src/native/managed/cdac/tests/SOSDacInterface8Tests.cs
+++ b/src/native/managed/cdac/tests/SOSDacInterface8Tests.cs
@@ -98,6 +98,18 @@ public unsafe class SOSDacInterface8Tests
 
     [Theory]
     [ClassData(typeof(MockTarget.StdArch))]
+    public void GetNumberGenerations_ServerGC_ReturnsCorrectCount(MockTarget.Architecture arch)
+    {
+        ISOSDacInterface8 dac8 = CreateSvrDac8(arch, out _);
+
+        uint numGenerations;
+        int hr = dac8.GetNumberGenerations(&numGenerations);
+        Assert.Equal(S_OK, hr);
+        Assert.Equal((uint)s_generations.Length, numGenerations);
+    }
+
+    [Theory]
+    [ClassData(typeof(MockTarget.StdArch))]
     public void GetGenerationTable_ReturnsCorrectData(MockTarget.Architecture arch)
     {
         ISOSDacInterface8 dac8 = CreateWksDac8(arch);


### PR DESCRIPTION
…EBUG loop bounds

- GetNumberGenerations: use gc.GetMaxGeneration()+1 via the GC contract instead of gc.GetHeapData() which throws on Server GC targets.
- GetGenerationTable/GetFinalizationFillPointers DEBUG cross-validation: limit comparison loops to pNeededLocal (the actual written count) instead of the caller buffer size to avoid comparing uninitialized trailing entries.
- GetFinalizationFillPointersSvr: use Math.Min(cFillPointers, pNeededLocal) for the same reason.